### PR TITLE
Fix incorrect image paths

### DIFF
--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { Github, ExternalLink } from 'lucide-react';
-import imgProjeto from '../assets/images/Portfolio.webp';
-import imgTrivia from '../assets/images/Trivia.webp';
+// Images are served from the public folder. Using absolute paths ensures the
+// correct base URL is applied in production builds.
 
 // Project Entries
 const projects = [
   {
     title: 'Trivia Quiz App',
     description: 'An interactive, themeable trivia quiz app built with React, TypeScript, and Tailwind CSS, fetching real-time questions from the OpenTDB API.',
-    img: 'public/assets/images/Trivia.webp',
+    img: '/assets/images/Trivia.webp',
     siteLink: 'https://andre-lmarinho.github.io/Trivia/',
     repoLink: 'https://github.com/andre-lmarinho/Trivia/',
     stacks: ['React', 'TypeScript','Tailwind CSS']
@@ -16,7 +16,7 @@ const projects = [
   {
     title: 'This Portfolio Site',
     description: 'Is this site that you are in to showcase my work.',
-    img: 'public/assets/images/Portfolio.webp',
+    img: '/assets/images/Portfolio.webp',
     siteLink: 'https://andre-lmarinho.github.io/Homepage/', 
     repoLink: 'https://github.com/andre-lmarinho/Homepage/',
     stacks: ['React', 'TypeScript','Tailwind CSS']


### PR DESCRIPTION
## Summary
- fix image paths in `Projects` section to use public assets

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f55fc663083228c5f09354b93249e