### PR TITLE
Add Navbar test for dark mode toggle

### DIFF
--- a/src/components/layouts/Navbar.test.tsx
+++ b/src/components/layouts/Navbar.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Navbar from './Navbar';
+
+function Wrapper({ onToggle }: { onToggle: (value: boolean) => void }) {
+  const [darkMode, setDarkMode] = React.useState(false);
+
+  React.useEffect(() => {
+    if (darkMode) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [darkMode]);
+
+  const handleToggle = (value: boolean) => {
+    setDarkMode(value);
+    onToggle(value);
+  };
+
+  return <Navbar darkMode={darkMode} setDarkMode={handleToggle} />;
+}
+
+describe('Navbar dark mode toggle', () => {
+  const style = document.createElement('style');
+  style.innerHTML = `
+    .hidden{display:none;}
+    .dark .dark\\:block{display:block !important;}
+    .dark .dark\\:hidden{display:none !important;}
+  `;
+
+  beforeEach(() => {
+    document.head.appendChild(style);
+    document.documentElement.classList.remove('dark');
+  });
+
+  afterEach(() => {
+    if (style.parentNode) {
+      style.parentNode.removeChild(style);
+    }
+  });
+
+  it('calls callback and toggles icons', async () => {
+    const toggle = vi.fn();
+    const { container, getByLabelText } = render(<Wrapper onToggle={toggle} />);
+
+    const button = getByLabelText('Toggle dark mode');
+    const moon = container.querySelector('svg.lucide-moon') as SVGElement;
+    const sun = container.querySelector('svg.lucide-sun') as SVGElement;
+
+    expect(window.getComputedStyle(moon).display).not.toBe('none');
+    expect(window.getComputedStyle(sun).display).toBe('none');
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(toggle).toHaveBeenCalledWith(true);
+    });
+
+    await waitFor(() => {
+      expect(window.getComputedStyle(moon).display).toBe('none');
+      expect(window.getComputedStyle(sun).display).not.toBe('none');
+    });
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,9 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   base: '/Homepage/',
-  plugins: [react()]
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
 })


### PR DESCRIPTION
## Summary
- configure Vitest to use jsdom
- add test for `<Navbar>` dark mode toggle

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f57a09ba88322864de641a12725c4