### PR TITLE
Fix image imports in Projects component

### DIFF
--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { Github, ExternalLink } from 'lucide-react';
-import imgProjeto from '../assets/images/Portfolio.webp';
-import imgTrivia from '../assets/images/Trivia.webp';
+import imgProjeto from '/assets/images/Portfolio.webp';
+import imgTrivia from '/assets/images/Trivia.webp';
 
 // Project Entries
 const projects = [
   {
     title: 'Trivia Quiz App',
     description: 'An interactive, themeable trivia quiz app built with React, TypeScript, and Tailwind CSS, fetching real-time questions from the OpenTDB API.',
-    img: 'public/assets/images/Trivia.webp',
+    img: imgTrivia,
     siteLink: 'https://andre-lmarinho.github.io/Trivia/',
     repoLink: 'https://github.com/andre-lmarinho/Trivia/',
     stacks: ['React', 'TypeScript','Tailwind CSS']
@@ -16,7 +16,7 @@ const projects = [
   {
     title: 'This Portfolio Site',
     description: 'Is this site that you are in to showcase my work.',
-    img: 'public/assets/images/Portfolio.webp',
+    img: imgProjeto,
     siteLink: 'https://andre-lmarinho.github.io/Homepage/', 
     repoLink: 'https://github.com/andre-lmarinho/Homepage/',
     stacks: ['React', 'TypeScript','Tailwind CSS']


### PR DESCRIPTION
## Summary
- update image imports to use Vite public asset path
- reference imported images instead of hardcoded paths

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f5c2a68388322a2f889f6576945b7