### PR TITLE
Disable central orb when about text reveals

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import SEO from './components/ui/SEO'
 
 export default function App() {
   const [darkMode, setDarkMode] = useState(false);
+  const [showCenterOrb, setShowCenterOrb] = useState(true);
 
   // When change darkMode, add or remove a class on <html>
   useEffect(() => {
@@ -30,7 +31,7 @@ export default function App() {
         image="https://andre-lmarinho.github.io/Homepage/social-preview.png"/>
 
       {/* Background */}
-      <AnimationBG />
+      <AnimationBG showCenterOrb={showCenterOrb} />
 
       <div className="relative z-20 flex flex-col min-h-screen">
       {/* Nav Menu */}
@@ -44,7 +45,7 @@ export default function App() {
         <Projects />
         {/* About Section */}
 
-        <About />
+        <About setShowCenterOrb={setShowCenterOrb} />
 
         {/* Stacks Section */}
         <Stacks />

--- a/src/components/layouts/AnimationBG.tsx
+++ b/src/components/layouts/AnimationBG.tsx
@@ -4,7 +4,15 @@ import React from 'react';
  * Full-screen animated background with orbs, mesh lines, and floating particles.
  * Utilizes Tailwind CSS utility classes and custom animations defined in tailwind.config.js.
  */
-export default function AnimationBG() {
+interface AnimationBGProps {
+  /**
+   * Whether the central pulsating orb should be visible.
+   * Defaults to true when the prop is not provided.
+   */
+  showCenterOrb?: boolean;
+}
+
+export default function AnimationBG({ showCenterOrb = true }: AnimationBGProps) {
   return (
     <div className="fixed z-10 inset-0 overflow-hidden pointer-events-none">
       {/* Top-right orb */}
@@ -14,7 +22,9 @@ export default function AnimationBG() {
       <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-gradient-to-tr from-accent-400 to-primary-500 rounded-full opacity-15 blur-3xl animate-float" />
 
       {/* Center orb */}
-      <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-64 h-64 bg-gradient-to-r from-secondary-400 to-accent-400 rounded-full opacity-10 blur-3xl animate-pulse-slow" />
+      {showCenterOrb && (
+        <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-64 h-64 bg-gradient-to-r from-secondary-400 to-accent-400 rounded-full opacity-10 blur-3xl animate-pulse-slow" />
+      )}
 
       {/* Animated mesh lines */}
       <div className="absolute inset-0 opacity-5 dark:opacity-10">

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -1,7 +1,13 @@
 import React, { useRef, useState, useEffect } from 'react';
 
+interface AboutProps {
+  /**
+   * Callback to control visibility of the center orb in the background.
+   */
+  setShowCenterOrb?: (value: boolean) => void;
+}
 
-export default function About() {
+export default function About({ setShowCenterOrb }: AboutProps) {
   const fullText = `I'm André, a front-end developer who bridges the gap between marketing strategy and technical execution. My journey from digital marketing to development has shaped my approach: every line of code is crafted with clear business outcomes in mind.
 
 Specializing in responsive and intuitive user interfaces built with React, TypeScript, and enhanced by analytics, I create digital experiences designed to not only engage but strategically drive results.
@@ -37,6 +43,11 @@ Let's build something remarkable together.`;
   const revealEnd = sectionTop + totalWords * REVEAL_SPACING;
   // Reveal in progress when scroll is within section reveal window
   const isRevealing = scrollBottom > sectionTop && scrollBottom < revealEnd;
+
+  // Hide or show the center orb based on reveal state
+  useEffect(() => {
+    setShowCenterOrb?.(!isRevealing);
+  }, [isRevealing, setShowCenterOrb]);
 
   // Total height to allow full reveal
   const sectionHeight = window.innerHeight + totalWords * REVEAL_SPACING;


### PR DESCRIPTION
## Summary
- allow `AnimationBG` to hide the central orb via prop
- store orb visibility in `App` and toggle from `About`

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685f65af3974832288dcba5062657710