### PR TITLE
Add tests for dark mode hook and RevealWord

### DIFF
--- a/src/components/ui/__tests__/RevealWord.test.tsx
+++ b/src/components/ui/__tests__/RevealWord.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { act, vi } from 'vitest';
+import RevealWord from '../RevealWord';
+
+vi.mock('framer-motion', async () => {
+  const React = await import('react');
+  return {
+    motion: {
+      span: React.forwardRef((props: any, ref) => <span ref={ref} {...props} />),
+    },
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+describe('RevealWord', () => {
+  let trigger: ((entries: IntersectionObserverEntry[]) => void) | undefined;
+
+  beforeEach(() => {
+    trigger = undefined;
+    (global as any).IntersectionObserver = class {
+      constructor(cb: any) { trigger = cb; }
+      observe() { }
+      disconnect() { }
+    };
+  });
+
+  it('wraps highlight word with gradient class', () => {
+    render(<RevealWord word="remarkable" index={0} paragraph={4} />);
+    const elem = screen.getByText('remarkable');
+    expect(elem.className).toContain('gradient-text');
+  });
+
+  it('shows icon when intersecting', () => {
+    render(<RevealWord word="React" index={2} paragraph={1} />);
+    expect(document.querySelector('svg')).toBeNull();
+    act(() => {
+      trigger?.([{ isIntersecting: true } as IntersectionObserverEntry]);
+    });
+    expect(document.querySelector('svg')).not.toBeNull();
+  });
+});

--- a/src/hooks/__tests__/useDarkMode.test.tsx
+++ b/src/hooks/__tests__/useDarkMode.test.tsx
@@ -1,0 +1,34 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import React from 'react';
+import useDarkMode from '../useDarkMode';
+
+function TestComponent({ initial = false }: { initial?: boolean }) {
+  const [dark, setDark] = useDarkMode(initial);
+  return <button onClick={() => setDark(!dark)}>{dark ? 'dark' : 'light'}</button>;
+}
+
+describe('useDarkMode', () => {
+  beforeEach(() => {
+    document.documentElement.classList.remove('dark');
+    document.body.classList.remove('dark');
+  });
+
+  it('toggles dark class on html and body', () => {
+    render(<TestComponent />);
+    const btn = screen.getByRole('button');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(document.body.classList.contains('dark')).toBe(false);
+    fireEvent.click(btn);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.body.classList.contains('dark')).toBe(true);
+    fireEvent.click(btn);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(document.body.classList.contains('dark')).toBe(false);
+  });
+
+  it('respects initial value', () => {
+    render(<TestComponent initial={true} />);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.body.classList.contains('dark')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest specs for `useDarkMode`
- add Vitest specs for `RevealWord` with IntersectionObserver mock

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615db5cb888322bc0205ed5ab14fa2