### PR TITLE
Remove unused dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "react-dom": "^18.2.0",
         "react-helmet-async": "^2.0.5",
         "react-icons": "^5.5.0",
-        "react-intersection-observer": "^9.16.0",
-        "react-text-swap-animation": "^1.4.0"
+        "react-intersection-observer": "^9.16.0"
       },
       "devDependencies": {
         "@testing-library/react": "^14.0.0",
@@ -2284,17 +2283,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/core-js": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
-      "integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5486,19 +5474,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-text-swap-animation": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/react-text-swap-animation/-/react-text-swap-animation-1.4.0.tgz",
-      "integrity": "sha512-gPVqpi96XIyxh5BZeFxloNn1CHpqcHsa26MFNqtjU0/eKjXMKl7IXdDlo80P7eyTrobv/at9L5TOm07ZmB1ufg==",
-      "license": "WTFPL",
-      "dependencies": {
-        "core-js": "^3.18.3"
-      },
-      "peerDependencies": {
-        "react": "^17.0.2 || ^18.2.0",
-        "react-dom": "^17.0.2 || ^18.2.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "react-dom": "^18.2.0",
     "react-helmet-async": "^2.0.5",
     "react-icons": "^5.5.0",
-    "react-intersection-observer": "^9.16.0",
-    "react-text-swap-animation": "^1.4.0"
+    "react-intersection-observer": "^9.16.0"
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",


### PR DESCRIPTION
## Summary
- remove `react-text-swap-animation` from dependencies
- update lockfile

## Testing
- `npm install --package-lock-only`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866eca003ac83229e0997e9c8878e2f