### PR TITLE
Update SEO default URL

### DIFF
--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -11,7 +11,7 @@ interface SEOProps {
 export default function SEO({
   title,
   description,
-  url = 'https://andre-lmarinho.github.io/Homepage/',
+  url = 'https://andre-lmarinho.github.io/Home/',
   image,
 }: SEOProps) {
   return (


### PR DESCRIPTION
## Summary
- update the default `url` in `SEO.tsx` so it points to `/Home/`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686af6f6772483228e08abba3790f982