### PR TITLE
Add dark mode class assertion to Navbar test

### DIFF
--- a/src/components/ui/__tests__/Navbar.test.tsx
+++ b/src/components/ui/__tests__/Navbar.test.tsx
@@ -56,11 +56,19 @@ describe('Navbar dark mode toggle', () => {
 
     await waitFor(() => {
       expect(toggle).toHaveBeenCalledWith(true);
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
     });
 
     await waitFor(() => {
       expect(window.getComputedStyle(moon).display).toBe('none');
       expect(window.getComputedStyle(sun).display).not.toBe('none');
+    });
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(toggle).toHaveBeenCalledWith(false);
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- extend Navbar component test to check the `dark` class is added/removed when toggling

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686af709ec8083228a2be2714817166d