### PR TITLE
Remove gh-pages snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,6 @@ _or_ deploy easily to Vercel or Netlify with the same settings.
 - `npm run deploy` — _(optional)_ build & publish to GitHub Pages (requires `predeploy` script)
 - `npm test` — run Vitest
 
-_Add these lines to `package.json` if using `gh-pages`:_
-
-```json
-"scripts": {
-  "predeploy": "npm run build",
-  "deploy": "gh-pages -d dist"
-}
-```
-
 ---
 
 ## ☁️ Deployment


### PR DESCRIPTION
## Summary
- remove README instructions to add the `predeploy` and `deploy` scripts

## Testing
- `npm run lint`
- `npm test` *(fails: RevealWord.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_686c3fc3dac88322bd5be47b27f3eee2